### PR TITLE
feat: added functionality to allow variable assignment

### DIFF
--- a/packages/call-func/CHANGELOG.md
+++ b/packages/call-func/CHANGELOG.md
@@ -1,5 +1,11 @@
 # eslint-plugin-call-func
 
+## 0.1.0
+
+### Minor Changes
+
+- Added functionality to allow variable assignment
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/call-func/README.md
+++ b/packages/call-func/README.md
@@ -4,13 +4,27 @@ This is a rule to encourage the use of specific func.
 
 ## Rule Details
 
-✓ GOOD:: function called
+✓ GOOD:: function called in outer function
 
 ```typescript
 function outer() {
   checkPermissions() // <-- This rule checks if this function is called.
   someFunc()
 }
+```
+
+✓ GOOD:: function called with variable assignment
+
+```typescript
+const runFunctionWithCheckPermission = (fn: () => void) => {
+  checkPermissions()
+  fn()
+}
+
+// ref: https://remix.run/docs/en/main/route/loader
+export const loader = runFunctionWithCheckPermission(() => { // <-- This rule also can checks if specific wrapper func is used.
+  console.log('function called after check permission')
+})
 ```
 
 ✗ BAD: No function called
@@ -32,6 +46,11 @@ This is useful when you want to run simple code within a framework that exports 
 export const loader = () => {
   checkPermissions()
 }
+
+// Or you can use a wrapper function to ensure that the permission check is performed.
+export const loader = runFunctionWithCheckPermission(() => {
+  console.log('function called after check permission')
+})
 ```
 
 ## Installation

--- a/packages/call-func/package.json
+++ b/packages/call-func/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-call-func",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "This is a rule to encourage the call of specific func",
   "main": "dist/index.js",
   "types": "./src/index.ts",

--- a/packages/call-func/src/lib/index.ts
+++ b/packages/call-func/src/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './isInnerFuncCalled'
+export * from './isInnerFuncEqualToOuterVariable'

--- a/packages/call-func/src/lib/isInnerFuncEqualToOuterVariable.ts
+++ b/packages/call-func/src/lib/isInnerFuncEqualToOuterVariable.ts
@@ -1,0 +1,14 @@
+import { TSESTree } from '@typescript-eslint/types'
+
+export const isInnerFuncEqualToOuterVariable = (
+  init: TSESTree.CallExpression,
+  matchedOuterVariable: string,
+  functionSets: {
+    outerFunction: string
+    innerFunction: string
+  }[],
+) =>
+  init.callee.type === 'Identifier' &&
+  init.callee.name ===
+    functionSets.find((f) => f.outerFunction === matchedOuterVariable)
+      ?.innerFunction

--- a/packages/call-func/test/call-func.test.ts
+++ b/packages/call-func/test/call-func.test.ts
@@ -43,6 +43,24 @@ ruleTester.run('rule: func-exist', rule, {
       ],
     },
     {
+      name: 'innerFunction equal to outerFunction (arrow func)',
+      code: 'const outer = inner()',
+      options: [
+        {
+          functionSets: [{ outerFunction: 'outer', innerFunction: 'inner' }],
+        },
+      ],
+    },
+    {
+      name: 'innerFunction (with args) equal to outerFunction (arrow func)',
+      code: `const outer = inner({ args: 'args' })`,
+      options: [
+        {
+          functionSets: [{ outerFunction: 'outer', innerFunction: 'inner' }],
+        },
+      ],
+    },
+    {
       name: 'no outerFunction exist(arrow func)',
       code: `
         const notOuter = () => {
@@ -97,6 +115,18 @@ ruleTester.run('rule: func-exist', rule, {
           notInnerFunc()
         }
         `,
+      errors: [
+        {
+          messageId: 'call-inner-func-in-outer-func',
+        },
+      ],
+      options: [
+        { functionSets: [{ outerFunction: 'outer', innerFunction: 'inner' }] },
+      ],
+    },
+    {
+      name: 'error when outerFunction not equal to innerFunction(arrow func)',
+      code: 'const outer = notInnerFunc()',
       errors: [
         {
           messageId: 'call-inner-func-in-outer-func',

--- a/packages/call-func/tsconfig.json
+++ b/packages/call-func/tsconfig.json
@@ -7,5 +7,5 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src"],
+  "include": ["src", "test"],
 }

--- a/packages/todo-comment/tsconfig.json
+++ b/packages/todo-comment/tsconfig.json
@@ -7,5 +7,5 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
Added functionality to allow variable assignment like below

```typescript
const runFunctionWithCheckPermission = (fn: () => void) => {
  checkPermissions()
  fn()
}

// ref: https://remix.run/docs/en/main/route/loader
export const loader = runFunctionWithCheckPermission(() => { // <-- This rule also can checks if specific wrapper func is used.
  console.log('function called after check permission')
})
```